### PR TITLE
Update com.jcraft:jsch to 0.1.55 for jgitflow-maven-plugin 

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -27,6 +27,9 @@
       <action type="update" dev="sseifert">
         Update plugins and dependencies to latest versions.
       </action>
+      <action type="update" dev="trichter">
+        Update com.jcraft:jsch to 0.1.55 for jgitflow-maven-plugin in order to support stronger cryptographic standards.
+      </action>
     </release>
 
     <release version="47" date="2022-09-30">

--- a/pom.xml
+++ b/pom.xml
@@ -873,6 +873,13 @@
             <autoVersionSubmodules>true</autoVersionSubmodules>
             <eol>lf</eol>
           </configuration>
+          <dependencies>
+            <dependency>
+              <groupId>com.jcraft</groupId>
+              <artifactId>jsch</artifactId>
+              <version>0.1.55</version>
+            </dependency>
+          </dependencies>
         </plugin>
 
       </plugins>


### PR DESCRIPTION
We have experienced issues in our toolchain during release because the used version com.jcraft:jsch does not play together with our cryptographic setup anymore.

```
[ERROR] Failed to execute goal external.atlassian.jgitflow:jgitflow-maven-plugin:1.0-m5.1:release-start (default-cli) on project org.example.project: Error starting release: Error starting release: org.eclipse.jgit.api.errors.TransportException: git@gitlab.example.org:example/project.git: Algorithm negotiation fail
```

This PR follows one of the possible solutions from https://ecosystem.atlassian.net/browse/MJF-299.
