### PR TITLE
spotbugs-findsecbugs-plugin: Stick with version 1.12.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,8 @@
     <maven-surefire-plugin.version>3.2.5</maven-surefire-plugin.version>
     <maven-release-plugin.version>3.0.1</maven-release-plugin.version>
     <spotbugs-plugin.version>4.8.5.0</spotbugs-plugin.version>
-    <spotbugs-findsecbugs-plugin.version>1.13.0</spotbugs-findsecbugs-plugin.version>
+    <!-- Stick with version 1.12.0 until the fix for https://github.com/find-sec-bugs/find-sec-bugs/issues/727 is released -->
+    <spotbugs-findsecbugs-plugin.version>1.12.0</spotbugs-findsecbugs-plugin.version>
     <pmd.version>7.2.0</pmd.version>
     <jacoco-maven-plugin.version>0.8.12</jacoco-maven-plugin.version>
     <versions-maven-plugin.version>2.16.2</versions-maven-plugin.version>


### PR DESCRIPTION
until the fix for https://github.com/find-sec-bugs/find-sec-bugs/issues/727 is released
Fixes #198 